### PR TITLE
move texts to better position depending on font-size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "rayon",
  "simple-xml-builder",
  "tempfile",
+ "unicode-segmentation",
  "uuid",
  "wild",
 ]
@@ -1591,6 +1592,12 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rayon = "1.10.0"
 hex_color = "3.0.0"
 itertools = "0.14"
 parley = "0.2.0"
+unicode-segmentation = "1.12.0"
 
 #[lints.clippy]
 #unwrap_used = "deny"

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@
 
 extern crate dxf;
 extern crate simple_xml_builder;
+extern crate unicode_segmentation;
 
 use anyhow::{Context, Ok, Result};
 use clap::Parser;

--- a/src/qelmt/dynamictext.rs
+++ b/src/qelmt/dynamictext.rs
@@ -3,6 +3,8 @@ use dxf::entities;
 use hex_color::HexColor;
 use simple_xml_builder::XMLElement;
 use uuid::Uuid;
+use unicode_segmentation::UnicodeSegmentation;
+
 
 use parley::{
     Alignment, FontContext, FontWeight, InlineBox, Layout, LayoutContext, PositionedLayoutItem,
@@ -29,13 +31,67 @@ pub struct DynamicText {
     text_width: i32,
     keep_visual_rotation: bool,
     color: HexColor,
+    attachment_point: i32,
+    reference_rectangle_width: f64,
 }
 
 impl From<&DynamicText> for XMLElement {
     fn from(txt: &DynamicText) -> Self {
         let mut dtxt_xml = XMLElement::new("dynamic_text");
-        dtxt_xml.add_attribute("x", two_dec(txt.x));
-        dtxt_xml.add_attribute("y", two_dec(txt.y));
+        // taken from QET_ElementScaler: "ElmtDynText::AsSVGstring"
+        //    // Position und Rotationspunkt berechnen:
+        //    posx = x + (size/8.0)+4.05 - 0.5;
+        //    posy = y + (7.0/5.0*size + 26.0/5.0) - 0.5;
+        //    rotx = (-1) * (((size/8.0)+4.05) - 0.5);
+        //    roty = (-1) * ((7.0/5.0*size + 26.0/5.0) - 0.5);
+        //
+        // reversed and slightly modified after looking at the result in element-editor:
+        //
+        let     _s: f64   = txt.font.point_size;
+        let mut _x: f64   = txt.x + 0.5 - (_s/8.0) - 4.05;
+        let     _y: f64   = txt.y + 0.5 - (7.0/5.0*_s + 26.0/5.0) + _s;
+        //
+        // we need the horizontal alignment and the text-width to move to right x-position:
+        // txt.reference_rectangle_width, // should be text-width (Group code 41)
+        // txt.attachment_point,  // Group code 71
+        //                        // 1 = Top left; 2 = Top center; 3 = Top right
+        //                        // 4 = Middle left; 5 = Middle center; 6 = Middle right
+        //                        // 7 = Bottom left; 8 = Bottom center; 9 = Bottom right
+        //
+        let mut _h_alignment: HAlignment = HAlignment::Left;
+        let mut _v_alignment: VAlignment = VAlignment::Top;
+        match txt.attachment_point {
+              1|4|7 => _h_alignment = HAlignment::Left,
+              2|5|8 => _h_alignment = HAlignment::Center,
+              3|6|9 => _h_alignment = HAlignment::Right,
+              _     => (),
+        };
+        match txt.attachment_point {
+              1|2|3 => _v_alignment = VAlignment::Top,
+              4|5|6 => _v_alignment = VAlignment::Center,
+              7|8|9 => _v_alignment = VAlignment::Bottom,
+              _     => (),
+        };
+        //
+        // it's just annoying if the value for "reference_rectangle_width" in the dxf is “0.0”...
+        //
+        // o.k. ... as long as we do not know the real width:
+        // "guess" the width by number of characters and font-size:
+        //
+        let     _n: usize = txt.text.graphemes(true).count();
+        let mut _w = (_n  as f64) * _s * 0.75;
+        if txt.reference_rectangle_width > 2.0 {
+            _w = txt.reference_rectangle_width;
+        }
+
+        match _h_alignment {
+            HAlignment::Left   => _x -=  0.0,
+            HAlignment::Center => _x -= _w / 2.0,
+            HAlignment::Right  => _x -= _w,
+        };
+
+        dtxt_xml.add_attribute("x", two_dec(_x));
+        dtxt_xml.add_attribute("y", two_dec(_y));
         dtxt_xml.add_attribute("z", two_dec(txt.z));
         dtxt_xml.add_attribute("rotation", two_dec(txt.rotation));
         dtxt_xml.add_attribute("uuid", format!("{{{}}}", txt.uuid));
@@ -97,6 +153,7 @@ impl ScaleEntity for DynamicText {
 
 pub struct DTextBuilder<'a> {
     text: TextEntity<'a>,
+    attach_point: i32,
     color: Option<HexColor>,
 }
 
@@ -105,6 +162,7 @@ impl<'a> DTextBuilder<'a> {
         Self {
             text: TextEntity::Text(text),
             color: None,
+            attach_point: dxf::enums::AttachmentPoint::BottomRight as i32,
         }
     }
 
@@ -112,6 +170,7 @@ impl<'a> DTextBuilder<'a> {
         Self {
             text: TextEntity::MText(text),
             color: None,
+            attach_point: dxf::enums::AttachmentPoint::BottomRight as i32,
         }
     }
 
@@ -123,7 +182,7 @@ impl<'a> DTextBuilder<'a> {
     }
 
     pub fn build(self) -> DynamicText {
-        let (x, y, z, rotation, style_name, text_height, value) = match self.text {
+        let (x, y, z, rotation, style_name, text_height, value, attachment_point, reference_rectangle_width) = match self.text {
             TextEntity::Text(txt) => (
                 txt.location.x,
                 -txt.location.y,
@@ -132,30 +191,32 @@ impl<'a> DTextBuilder<'a> {
                 &txt.text_style_name,
                 txt.text_height,
                 txt.value.clone(),
+                dxf::enums::AttachmentPoint::BottomRight as i32, // as Placeholder: no AttachmentPoint with Text!!!
+                0.0, // as Placeholder: no "reference_rectangle_width" with Text!!!
             ),
-            TextEntity::MText(mtxt) => {
-                (
-                    mtxt.insertion_point.x,
-                    -mtxt.insertion_point.y,
-                    mtxt.insertion_point.z,
-                    mtxt.rotation_angle,
-                    &mtxt.text_style_name,
-                    //I'm not sure what the proper value is here for Mtext
-                    //becuase I haven't actually finished supporting it.
-                    //I'll put initial text height for now. But i'm not certain
-                    //exactly what this correlates to. There is also vertical_height,
-                    //which I would guess is the total vertical height for all the lines
-                    //it's possible I would need to take the vertical height and divide
-                    //by the number of lines to get the value I need....I'm not sure yet
-                    mtxt.initial_text_height,
-                    //There are 2 text fields on MTEXT, .text a String and .extended_text a Vec<String>
-                    //Most of the example files I have at the moment are single line MTEXT.
-                    //I edited one of them in QCad, and added a few lines. The value came through in the text field
-                    //with extended_text being empty, and the newlines were deliniated by '\\P'...I might need to look
-                    //the spec a bit to determine what it says for MTEXT, but for now, I'll just assume this is correct
-                    mtxt.text.replace("\\P", "\n"),
-                )
-            }
+            TextEntity::MText(mtxt) => (
+                mtxt.insertion_point.x,
+                -mtxt.insertion_point.y,
+                mtxt.insertion_point.z,
+                mtxt.rotation_angle,
+                &mtxt.text_style_name,
+                //I'm not sure what the proper value is here for Mtext
+                //becuase I haven't actually finished supporting it.
+                //I'll put initial text height for now. But i'm not certain
+                //exactly what this correlates to. There is also vertical_height,
+                //which I would guess is the total vertical height for all the lines
+                //it's possible I would need to take the vertical height and divide
+                //by the number of lines to get the value I need....I'm not sure yet
+                mtxt.initial_text_height,
+                //There are 2 text fields on MTEXT, .text a String and .extended_text a Vec<String>
+                //Most of the example files I have at the moment are single line MTEXT.
+                //I edited one of them in QCad, and added a few lines. The value came through in the text field
+                //with extended_text being empty, and the newlines were deliniated by '\\P'...I might need to look
+                //the spec a bit to determine what it says for MTEXT, but for now, I'll just assume this is correct
+                mtxt.text.replace("\\P", "\n"),
+                mtxt.attachment_point as i32,
+                mtxt.reference_rectangle_width,
+            ),
         };
 
         // Create a FontContext (font database) and LayoutContext (scratch space).
@@ -213,9 +274,10 @@ impl<'a> DTextBuilder<'a> {
                     ..Default::default()
                 }
             },
-            h_alignment: HAlignment::Center,
-            v_alignment: VAlignment::Center,
-
+            attachment_point: attachment_point as i32, //liest aus der dxf-Datei!!!
+            reference_rectangle_width: reference_rectangle_width, //liest aus der dxf-Datei!!!
+            h_alignment: HAlignment::Left,
+            v_alignment: VAlignment::Top,
             text_from: "UserText".into(),
             frame: false,
             

--- a/src/qelmt/dynamictext.rs
+++ b/src/qelmt/dynamictext.rs
@@ -162,7 +162,7 @@ impl<'a> DTextBuilder<'a> {
         Self {
             text: TextEntity::Text(text),
             color: None,
-            attach_point: dxf::enums::AttachmentPoint::BottomRight as i32,
+            attach_point: dxf::enums::AttachmentPoint::TopLeft as i32,
         }
     }
 
@@ -170,7 +170,7 @@ impl<'a> DTextBuilder<'a> {
         Self {
             text: TextEntity::MText(text),
             color: None,
-            attach_point: dxf::enums::AttachmentPoint::BottomRight as i32,
+            attach_point: dxf::enums::AttachmentPoint::TopLeft as i32,
         }
     }
 
@@ -191,7 +191,7 @@ impl<'a> DTextBuilder<'a> {
                 &txt.text_style_name,
                 txt.text_height,
                 txt.value.clone(),
-                dxf::enums::AttachmentPoint::BottomRight as i32, // as Placeholder: no AttachmentPoint with Text!!!
+                dxf::enums::AttachmentPoint::TopLeft as i32, // as Placeholder: no AttachmentPoint with Text!!!
                 0.0, // as Placeholder: no "reference_rectangle_width" with Text!!!
             ),
             TextEntity::MText(mtxt) => (

--- a/src/qelmt/text.rs
+++ b/src/qelmt/text.rs
@@ -34,7 +34,7 @@ impl From<(&entities::Text, HexColor)> for Text {
                 Default::default()
             },
             value: txt.value.clone(),
-            attach_point: dxf::enums::AttachmentPoint::BottomRight as i32,
+            attach_point: dxf::enums::AttachmentPoint::TopLeft as i32,
 	    reference_rectangle_width: 0.0,
         }
     }

--- a/src/qelmt/text.rs
+++ b/src/qelmt/text.rs
@@ -11,6 +11,8 @@ pub struct Text {
     pub y: f64,
     font: FontInfo,
     color: HexColor,
+    attach_point: i32,
+    reference_rectangle_width: f64,
 }
 
 impl From<(&entities::Text, HexColor)> for Text {
@@ -32,6 +34,8 @@ impl From<(&entities::Text, HexColor)> for Text {
                 Default::default()
             },
             value: txt.value.clone(),
+            attach_point: dxf::enums::AttachmentPoint::BottomRight as i32,
+	    reference_rectangle_width: 0.0,
         }
     }
 }


### PR DESCRIPTION
currently this works quite good for texts **without** rotation.
For rotated texts the rotation-point has to be calculated as well.
I left some comments in sources to see where and why I've done things.

note:
When converting the file "8302K738_Wet-Location Cord Grip.dxf"  
from QET-Forum, you'll see, why the length of line-endings shall 
be limited: The endings are almost as long as the line itself!
That looks very disturbing, because the Arrow-tip in original
is quite small but in element-file **very** big.